### PR TITLE
Add default admin token

### DIFF
--- a/api/config/server.js
+++ b/api/config/server.js
@@ -1,7 +1,7 @@
 module.exports = ({ env }) => ({
   admin: {
     auth: {
-      secret: env('ADMIN_JWT_SECRET'),
+      secret: env('ADMIN_JWT_SECRET') || 'tnesataei',
     },
   },
   host: env('HOST', '0.0.0.0'),


### PR DESCRIPTION
The [create-first-administrator.js](https://github.com/strapi/foodadvisor/blob/demonstration/api/scripts/create-first-administrator.js) script inserts an encrypted password, so the auth secret has to be hardcoded in the code.

The alternative was to send the env variables from the website API, but since it is not sensitive, I think we can keep it here.

Please let me know what you think.