### PR TITLE
Fix path lines in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ git clone https://github.com/strapi/foodadvisor.git
 
 ## 2. Start Strapi from the ./api folder
 
-`Path: ./my-projects/api/`:
+`Path: ./my-projects/foodadvisor/`:
 
 Run the following from your command line:
 
@@ -26,7 +26,7 @@ You will find more information and options in the [**api** README](./api).
 
 ## 3. Start the front-end from the ./client folder
 
-`Path: ./my-projects/client/`:
+`Path: ./my-projects/foodadvisor/`:
 
 Run the following from your command line:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ git clone https://github.com/strapi/foodadvisor.git
 
 ## 2. Start Strapi from the ./api folder
 
-`Path: ./my-projects/foodadvisor/`:
+`Path: ./my-projects/foodadvisor/api`:
 
 Run the following from your command line:
 
@@ -26,7 +26,7 @@ You will find more information and options in the [**api** README](./api).
 
 ## 3. Start the front-end from the ./client folder
 
-`Path: ./my-projects/foodadvisor/`:
+`Path: ./my-projects/foodadvisor/client`:
 
 Run the following from your command line:
 


### PR DESCRIPTION
Although the instructions are very clear, I think the paths are incorrect. For instance, if I'm in `my-projects/` and I clone the repo, the path will be `my-projects/foodadvisor/`, so the `api/` and `client/` directories will be `my-projects/foodadvisor/api/` and `my-projects/foodadvisor/client/` respectively, not `my-projects/api/` and `my-projects/client/`.

Finally, I think it's more coherent to say that the path line below the steps headings is `my-projects/foodadvisor/` instead of `my-projects/foodadvisor/api/` and `my-projects/foodadvisor/client/`, because the next line is saying we'll change directory to `api/` and `client/`.