### PR TITLE
Fix sanitize of response data for restaurant and reviews

### DIFF
--- a/api/api/restaurant/controllers/Restaurant.js
+++ b/api/api/restaurant/controllers/Restaurant.js
@@ -1,3 +1,5 @@
+const { sanitizeEntity } = require('strapi-utils');
+
 module.exports = {
   find: async (ctx) => {
     let restaurants;
@@ -10,6 +12,7 @@ module.exports = {
 
     restaurants = await Promise.all(
       restaurants.map(async (restaurant) => {
+        sanitizeEntity(restaurant, { model: strapi.models.restaurant });
         restaurant.note = await strapi.api.review.services.review.average(restaurant.id);
 
         return restaurant;
@@ -62,6 +65,6 @@ module.exports = {
       restaurant.noteDetails.push(detail);
     }
 
-    return restaurant;
-  }
+    return sanitizeEntity(restaurant, { model: strapi.models.restaurant });
+  },
 };

--- a/api/api/review/controllers/Review.js
+++ b/api/api/review/controllers/Review.js
@@ -1,19 +1,15 @@
 'use strict';
 
-/**
- * Review.js controller
- *
- * @description: A set of functions called "actions" for managing `Review`.
- */
+const { sanitizeEntity } = require('strapi-utils');
 
 module.exports = {
   create: async (ctx) => {
     // Set the reviewer ID as author key based on the login user info.
     // https://strapi.io/documentation/3.x.x/guides/authentication.html#user-object-in-strapi-context
     try {
-      ctx.request.body.author = ctx.state.user.id
+      ctx.request.body.author = ctx.state.user.id;
     } catch (err) {
-      return ctx.badRequest(null, 'Can\'t find authenticated user ID');
+      return ctx.badRequest(null, "Can't find authenticated user ID");
     }
 
     if (!ctx.request.body.restaurant) {
@@ -34,6 +30,8 @@ module.exports = {
       return ctx.badRequest(null, '`note` attribute have to be between 0 and 5');
     }
 
-    return strapi.api.review.services.review.create(ctx.request.body);
-  }
+    let review = await strapi.api.review.services.review.create(ctx.request.body);
+
+    return sanitizeEntity(review, { model: strapi.models.review });
+  },
 };

--- a/api/package.json
+++ b/api/package.json
@@ -40,7 +40,7 @@
     "uuid-v4": "^0.1.0"
   },
   "strapi": {
-    "uuid": "FOODADVISOR-30671326-1c5a-4d9d-9a66-b6862cf0b7e7"
+    "uuid": "7b581c0d-89b7-479e-b379-a76ab90b8754"
   },
   "engines": {
     "node": ">= 10.0.0",


### PR DESCRIPTION
Added the sanitizeEntity function into the restaurant find and findOne as well as the review create.

Not sure if these custom controllers are needed anymore and if not feel free to close this out. Since we talked about it in the meeting figured I'd try to be the first to submit the PR :)