### PR TITLE
Update gitpod node versions

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full:latest
+
+RUN bash -c ". .nvm/nvm.sh     && nvm install 14     && nvm use 14     && nvm alias default 14"
+
+RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,5 @@
+image:
+  file: .gitpod.Dockerfile
 tasks:
   - name: Strapi
     init: >

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the following:
 - Strapi project with existing Content-types and data (`/api`)
 - Next.js client ready to fetch the content of the Strapi application (`/client`)
 
-[![Open in Gitpod](https://camo.githubusercontent.com/76e60919474807718793857d8eb615e7a50b18b04050577e5a35c19421f260a3/68747470733a2f2f676974706f642e696f2f627574746f6e2f6f70656e2d696e2d676974706f642e737667)](http://gitpod.io/#https://github.com/strapi/foodadvisor/tree/v2)
+[![Open in Gitpod](https://camo.githubusercontent.com/76e60919474807718793857d8eb615e7a50b18b04050577e5a35c19421f260a3/68747470733a2f2f676974706f642e696f2f627574746f6e2f6f70656e2d696e2d676974706f642e737667)](http://gitpod.io/#https://github.com/strapi/foodadvisor)
 
 ## Get started
 


### PR DESCRIPTION
This PR makes the FA Gitpod workspace use version 14 of node instead of the 16 that have been added to their default workspace recently