### PR TITLE
Fix Restaurants index page blocks not shown

### DIFF
--- a/client/pages/restaurants/index.js
+++ b/client/pages/restaurants/index.js
@@ -24,7 +24,7 @@ const Restaurants = ({
   const [categoryId, setCategoryId] = useState(null);
   const [pageNumber, setPageNumber] = useState(1);
 
-  const blocks = delve(pageData, "blocks");
+  const blocks = delve(pageData, "attributes.blocks");
   const header = delve(pageData, "attributes.header");
   const placeText = delve(pageData, "attributes.placeText");
   const categoryText = delve(pageData, "attributes.categoryText");

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -63,7 +63,7 @@ export function getData(slug, locale, apiID, kind, preview) {
       slug: slugToReturn,
     };
   } else {
-    const apiUrl = `/${apiID}?locale=${locale}${previewParams}&populate[blocks][populate]=*&populate=localizations&populate[header]=*`;
+    const apiUrl = `/${apiID}?locale=${locale}${previewParams}&populate[blocks][populate]=*,buttons.link&populate=localizations&populate[header]=*`;
 
     if (apiID.includes('-page')) {
       const slugToReturn =


### PR DESCRIPTION
Restaurants index page does not show any blocks because of a typo.

Additionally, updates getData util to populate buttons.links in blocks in single types.