### PR TITLE
Change nvm version to be compatible with required libraries.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,5 @@
 FROM gitpod/workspace-full:latest
 
-RUN bash -c ". .nvm/nvm.sh     && nvm install 14     && nvm use 14     && nvm alias default 14"
+RUN bash -c ". .nvm/nvm.sh     && nvm install 16     && nvm use 16     && nvm alias default 16"
 
 RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix


### PR DESCRIPTION
While starting the repo in a gitpod workspace, yarn install command for Strapi task gives error since a package needs node >= 16  so changing the workspace docker file to use nvm 16 fixes this problem. 